### PR TITLE
Add cool down period after login shell

### DIFF
--- a/zsh-bench
+++ b/zsh-bench
@@ -235,6 +235,7 @@ function script() {
   local out
   out=$(HOST=${host} TERM=xterm-256color LINES=$lines COLUMNS=$columns \
           command zsh -lic '"builtin" "exit"' 2>&1 </dev/null || true)
+  command sleep 1
   if [[ $out == *${~prompt_pat}* ]]; then
     print -ru2 -- "${ZSH_SCRIPT:t}: zsh is printing hostname or the last part of the current directory"
     return 1
@@ -418,6 +419,7 @@ repeat $iters[2]; do
   local -F start=EPOCHREALTIME
   command zsh -lic '"builtin" "exit"' </dev/null &>/dev/null || true
   local -F took_ms='1e3 * (EPOCHREALTIME - start)'
+  command sleep 1
   if (( ! $+exit_time_ms || took_ms < exit_time_ms )); then
     local -F3 exit_time_ms=took_ms
   fi


### PR DESCRIPTION
**zim** and **prezto** run a disowned background job in login shells (check their respective .zlogin files). A cool down period is needed to let these jobs finish, otherwise the jobs will start accumulating when in a loop of login shell runs, interfering with the current shell execution times.

Not sure if I've covered all the changes needed to make sure there is a cool down period of 1 second after a login shell running one of the mentioned frameworks finishes.
