### PR TITLE
Update zim+ config for version 1.7.0

### DIFF
--- a/configs/zim+/skel/.zimrc
+++ b/configs/zim+/skel/.zimrc
@@ -1,4 +1,4 @@
-zmodule completion --use degit
-zmodule zsh-users/zsh-syntax-highlighting --use degit
-zmodule zsh-users/zsh-autosuggestions --use degit
-zmodule romkatv/powerlevel10k --use degit
+zmodule completion
+zmodule zsh-users/zsh-syntax-highlighting
+zmodule zsh-users/zsh-autosuggestions
+zmodule romkatv/powerlevel10k

--- a/configs/zim+/skel/.zlogin
+++ b/configs/zim+/skel/.zlogin
@@ -1,1 +1,0 @@
-source ${ZIM_HOME}/login_init.zsh -q &!

--- a/configs/zim+/skel/.zshenv
+++ b/configs/zim+/skel/.zshenv
@@ -1,3 +1,1 @@
 setopt no_global_rcs
-
-ZIM_HOME=~/.zim

--- a/configs/zim+/skel/.zshrc
+++ b/configs/zim+/skel/.zshrc
@@ -3,6 +3,8 @@ if [[ -z ${TMUX+X}${ZSH_SCRIPT+X}${ZSH_EXECUTION_STRING+X} ]]; then
   exec tmux
 fi
 
+ZIM_HOME=~/.zim
+zstyle ':zim:zmodule' use 'degit'
 if [[ ! -e $ZIM_HOME/zimfw.zsh ]]; then
   # Download zimfw script if missing.
   curl -fsSLo $ZIM_HOME/zimfw.zsh --create-dirs \
@@ -10,8 +12,7 @@ if [[ ! -e $ZIM_HOME/zimfw.zsh ]]; then
 fi
 if [[ ! $ZIM_HOME/init.zsh -nt ~/.zimrc ]]; then
   # Install missing modules and update $ZIM_HOME/init.zsh.
-  source $ZIM_HOME/zimfw.zsh install |
-    grep -vF 'Done with install. Restart your terminal for any changes to take effect.'
+  source $ZIM_HOME/zimfw.zsh init
 fi
 
 # Activate Powerlevel10k Instant Prompt.


### PR DESCRIPTION
which updated the `zimfw init` action output. The login_init.zsh file was deprecated, so no need to source it anymore, which means no background compiling anynmore.

Also, set degit as the default, instead of setting it in each individual zmodule.
