### PR TITLE
completion module is optional in prezto and zim

### DIFF
--- a/configs/prezto+/skel/.zpreztorc
+++ b/configs/prezto+/skel/.zpreztorc
@@ -1,3 +1,3 @@
 zstyle ':prezto:*:*' color 'yes'
-zstyle ':prezto:load' pmodule 'completion' 'autosuggestions' 'syntax-highlighting' 'prompt'
+zstyle ':prezto:load' pmodule 'autosuggestions' 'syntax-highlighting' 'prompt'
 zstyle ':prezto:module:prompt' theme 'powerlevel10k'

--- a/configs/prezto+/skel/.zshrc
+++ b/configs/prezto+/skel/.zshrc
@@ -6,5 +6,11 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
+# Load and initialize the completion system.
+autoload -Uz compinit && compinit
+if [[ ! ~/.zcompdump.zwc -nt ~/.zcompdump ]]; then
+  zcompile ~/.zcompdump
+fi
+
 ZSH_AUTOSUGGEST_MANUAL_REBIND=1
 source ~/.p10k.zsh

--- a/configs/zim+/skel/.zimrc
+++ b/configs/zim+/skel/.zimrc
@@ -1,4 +1,3 @@
-zmodule completion
 zmodule zsh-users/zsh-syntax-highlighting
 zmodule zsh-users/zsh-autosuggestions
 zmodule romkatv/powerlevel10k

--- a/configs/zim+/skel/.zshrc
+++ b/configs/zim+/skel/.zshrc
@@ -5,19 +5,25 @@ fi
 
 ZIM_HOME=~/.zim
 zstyle ':zim:zmodule' use 'degit'
+# Download zimfw plugin manager if missing.
 if [[ ! -e $ZIM_HOME/zimfw.zsh ]]; then
-  # Download zimfw script if missing.
   curl -fsSLo $ZIM_HOME/zimfw.zsh --create-dirs \
     https://github.com/zimfw/zimfw/releases/latest/download/zimfw.zsh
 fi
+# Install missing modules, and update $ZIM_HOME/init.zsh if missing or outdated.
 if [[ ! $ZIM_HOME/init.zsh -nt ~/.zimrc ]]; then
-  # Install missing modules and update $ZIM_HOME/init.zsh.
   source $ZIM_HOME/zimfw.zsh init
 fi
 
 # Activate Powerlevel10k Instant Prompt.
 if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
+# Load and initialize the completion system.
+autoload -Uz compinit && compinit
+if [[ ! ~/.zcompdump.zwc -nt ~/.zcompdump ]]; then
+  zcompile ~/.zcompdump
 fi
 
 ZSH_AUTOSUGGEST_MANUAL_REBIND=1


### PR DESCRIPTION
So it can be disabled if you want a more barebones set up, like the other "+" configurations.
