### PR TITLE
update ubuntu docker tag

### DIFF
--- a/zsh-bench
+++ b/zsh-bench
@@ -139,7 +139,7 @@ if (( ARGC )); then
         done
       }
 
-      local -r img=ubuntu:21.04
+      local -r img=ubuntu:22.04
 
       function docker-run() {
         DOCKER_CONTENT_TRUST=1 command docker run -e LC_ALL=C.UTF-8 --rm -i --init -- \

--- a/zsh-playground
+++ b/zsh-playground
@@ -123,7 +123,7 @@ fi
   done
 }
 
-local -r img=ubuntu:21.04
+local -r img=ubuntu:22.04
 
 function docker-run() {
   local flags=(-i --rm --init -e TERM -e COLORTERM -e LC_ALL=C.UTF-8 -w /root)


### PR DESCRIPTION
ubuntu 21.04 reached EOL in [january](https://lists.ubuntu.com/archives/ubuntu-announce/2022-January/000276.html) of this year, which causes the script to fail when run with `--isolation docker` due to the mirrors no longer being available. bumping the tag to 22.04 fixes this and prevents it from happening again until it's EOL in 2032 (fingers crossed)