### PR TITLE
document config-dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ git clone https://github.com/romkatv/zsh-bench ~/zsh-bench
 
 ## Usage
 
+```text
+usage: zsh-bench [OPTION].. [CONFIG]..
+
+OPTIONS
+  -h,--help
+  -i,--iters <NUM> [default=16]
+  -l,--login <yes|no> [default=yes]
+  -g,--git <yes|no|empty> [default=yes]
+  -c,--config-dir <directory> [default=configs dir in zsh-bench dir]
+  -d,--scratch-dir <directory>
+  -I,--isolation <docker|user>
+  -s,--standalone
+  -r,--raw
+```
+
 ### Benchmark zsh on your machine
 
 ```zsh

--- a/zsh-bench
+++ b/zsh-bench
@@ -50,6 +50,7 @@ if (( $#help )); then
   print -r -- '  -i,--iters <NUM> [default=16]'
   print -r -- '  -l,--login <yes|no> [default=yes]'
   print -r -- '  -g,--git <yes|no|empty> [default=yes]'
+  print -r -- "  -c,--config-dir <directory> [default=${self_dir}/configs]"
   print -r -- '  -d,--scratch-dir <directory>'
   print -r -- '  -I,--isolation <docker|user>'
   print -r -- '  -s,--standalone'


### PR DESCRIPTION
- For #22

Adds config-dir to `zsh-bench --help`, and adds the `zsh-bench --help` to the README.