### PR TITLE
fix: avoid deadlock with zinit turbo mode (wait ice)

### DIFF
--- a/internal/-zb-benchmark-input
+++ b/internal/-zb-benchmark-input
@@ -42,11 +42,21 @@
     -zb-benchmark-input-ready() {
       builtin emulate -L zsh -o no_unset -o warn_create_global || builtin exit
       if [[ -v ZINIT_SICE && -v ZINIT_REGISTERED_PLUGINS && -v ZINIT_SNIPPETS ]]; then
-        builtin local requested loaded missing
+        builtin local requested loaded missing sched_out line
         requested=(${(kou)ZINIT_SICE})
         loaded=(${(ou)ZINIT_REGISTERED_PLUGINS} ${(kou)ZINIT_SNIPPETS})
         missing=(${requested:|loaded})
-        (( ! $#missing )) || builtin return
+        if (( $#missing )); then
+          # Zinit turbo mode (wait ice) defers plugin loading until AFTER prompt display.
+          # Check if zinit is still in active loading mode (not following mode).
+          sched_out="$(sched 2>/dev/null)"
+          for line in ${(f)sched_out}; do
+            # If any non-following zinit-scheduler exists, wait for it
+            if [[ $line == *@zinit-scheduler* && $line != *following* ]]; then
+              builtin return 1
+            fi
+          done
+        fi
       fi
       [[ -z ${_zsh_defer_tasks-} ]]
     }


### PR DESCRIPTION
## Problem

When using zinit with turbo mode (`wait` ice), zsh-bench hangs indefinitely during benchmarking.

Zinit turbo mode defers plugin loading until AFTER the prompt is displayed. However, the existing `-zb-benchmark-input-ready` function waits for ALL plugins in `ZINIT_SICE` to be loaded before proceeding, causing a deadlock:

1. zsh-bench waits for all plugins to load before showing prompt
2. zinit waits for prompt before loading deferred plugins
3. Deadlock

## Solution

Check if zinit's scheduler is in "following" mode, which indicates that initial synchronous loading is complete. In this mode, remaining unloaded plugins are intentionally deferred until after the prompt, so we should not wait for them.

- If any `@zinit-scheduler` entry is NOT in "following" mode → wait (still loading)
- If all `@zinit-scheduler` entries are in "following" mode → proceed (deferred loading is by design)