### PR TITLE
Fix script invocation broken on util-linux 2.39+

### DIFF
--- a/zsh-bench
+++ b/zsh-bench
@@ -293,7 +293,7 @@ if script_version=$(LC_ALL=C script -V 2>/dev/null) &&
   local -ir bsd_script=0
 
   function script() {
-    with-env command script -fqec "${(j: :)@:2}" -- "$1" >/dev/null
+    with-env command script -fqec "${(j: :)@:2}" "$1" >/dev/null
   }
 else
   local -ir bsd_script=1


### PR DESCRIPTION
On util-linux 2.39+, `script -c CMD -- LOGFILE` errors with:

      script: option --command and a command after '--' cannot be combined

  util-linux 2.39 added support for passing a command after `--`, which now collides with `-c`. The `--` separator is no longer accepted
  alongside `-c`.

  Fix: drop `--`; `script -fqec CMD LOGFILE` still works on all util-linux versions that support `-c` (i.e. all currently-shipping
  releases).

  Reproducer on Arch / util-linux 2.42:

  $ script -fqec "echo hi" -- /dev/null
  script: option --command and a command after '--' cannot be combined

  Verified `zsh-bench` runs to completion after the patch.
